### PR TITLE
Fix typo: ingradients -> ingredients

### DIFF
--- a/pizzeria/helpers.py
+++ b/pizzeria/helpers.py
@@ -1,7 +1,7 @@
 from .types import PIZZAS
 
-def get_unique_ingradients(listOfPizzas):
-    ingradients = []
+def get_unique_ingredients(listOfPizzas):
+    ingredients = []
     for pizza in listOfPizzas:
-        ingradients += PIZZAS[pizza]
-    return set(sorted(ingradients))
+        ingredients += PIZZAS[pizza]
+    return set(sorted(ingredients))

--- a/pizzeria/types.py
+++ b/pizzeria/types.py
@@ -1,4 +1,4 @@
-# Ingradients
+# Ingredients
 PIZZAS = [
     ['onion','pepper','olive'],
     ['mushroom','tomato','basil'],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,21 +1,21 @@
 import unittest
-from pizzeria.helpers import get_unique_ingradients
+from pizzeria.helpers import get_unique_ingredients
 from pizzeria.types import PIZZAS
 
 
 class HelpersTestCase(unittest.TestCase):
-    def test_unique_ingradients(self):
+    def test_unique_ingredients(self):
         pizzas = [0]
 
-        ingradients = get_unique_ingradients(pizzas)
+        ingredients = get_unique_ingredients(pizzas)
 
-        self.assertEqual(ingradients,set(PIZZAS[0]))
+        self.assertEqual(ingredients,set(PIZZAS[0]))
 
     
-    def test_unique_all_ingradients(self):
+    def test_unique_all_ingredients(self):
         pizzas = [0,1,2,3,4]
 
-        result = get_unique_ingradients(pizzas)
+        result = get_unique_ingredients(pizzas)
 
         expected_result = set(sorted([
             "onion",


### PR DESCRIPTION
All tests passing:

```
(venv) Mauros-MacBook:pizzeria mauro$ git push --set-upstream origin bugfix/ingredients
Branch 'bugfix/ingredients' set up to track remote branch 'bugfix/ingredients' from 'origin'.
Everything up-to-date
(venv) Mauros-MacBook:pizzeria mauro$ coverage run -m unittest
..
----------------------------------------------------------------------
Ran 2 tests in 0.002s

OK
(venv) Mauros-MacBook:pizzeria mauro$ coverage report -m
Name                    Stmts   Miss  Cover   Missing
-----------------------------------------------------
pizzeria/__init__.py        0      0   100%
pizzeria/helpers.py         6      0   100%
pizzeria/types.py           1      0   100%
tests/__init__.py           0      0   100%
tests/test_helpers.py      13      0   100%
-----------------------------------------------------
TOTAL                      20      0   100%
(venv) Mauros-MacBook:pizzeria mauro$ 
```
