### PR TITLE
Refactor get_unique_ingredients()

### DIFF
--- a/pizzeria/helpers.py
+++ b/pizzeria/helpers.py
@@ -1,5 +1,5 @@
 def get_unique_ingredients(list_of_pizzas):
-    ingredients = set([])
+    ingredients = []
     for pizza in list_of_pizzas:
-        ingredients = ingredients.union(pizza)
-    return ingredients
+        ingredients += pizza
+    return set(ingredients)

--- a/pizzeria/helpers.py
+++ b/pizzeria/helpers.py
@@ -1,7 +1,5 @@
-from .types import PIZZAS
-
-def get_unique_ingredients(listOfPizzas):
-    ingredients = []
-    for pizza in listOfPizzas:
-        ingredients += PIZZAS[pizza]
-    return set(sorted(ingredients))
+def get_unique_ingredients(list_of_pizzas):
+    ingredients = set([])
+    for pizza in list_of_pizzas:
+        ingredients = ingredients.union(pizza)
+    return ingredients

--- a/pizzeria/types.py
+++ b/pizzeria/types.py
@@ -1,8 +1,0 @@
-# Ingredients
-PIZZAS = [
-    ['onion','pepper','olive'],
-    ['mushroom','tomato','basil'],
-    ['chicken','mushroom','pepper'],
-    ['tomato','mushroom','basil'],
-    ['chicken','basil']
-]

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,23 +1,19 @@
 import unittest
 from pizzeria.helpers import get_unique_ingredients
-from pizzeria.types import PIZZAS
 
 
 class HelpersTestCase(unittest.TestCase):
-    def test_unique_ingredients(self):
-        pizzas = [0]
+    # From page 2 of practice_round_2021_v3.pdf
+    # Can they be reused?
+    SAMPLE_PIZZAS = [
+        ['onion', 'pepper', 'olive'],
+        ['mushroom', 'tomato', 'basil'],
+        ['chicken', 'mushroom', 'pepper'],
+        ['tomato', 'mushroom', 'basil'],
+        ['chicken', 'basil']
+    ]
 
-        ingredients = get_unique_ingredients(pizzas)
-
-        self.assertEqual(ingredients,set(PIZZAS[0]))
-
-    
-    def test_unique_all_ingredients(self):
-        pizzas = [0,1,2,3,4]
-
-        result = get_unique_ingredients(pizzas)
-
-        expected_result = set(sorted([
+    SAMPLE_UNIQUE_INGREDIENTS = set([
             "onion",
             "pepper",
             "mushroom",
@@ -25,7 +21,22 @@ class HelpersTestCase(unittest.TestCase):
             "chicken",
             "tomato",
             "olive"
-        ]))
+        ])
 
-        self.assertEqual(result, expected_result)
-    
+    def test_unique_ingredients(self):
+        pizzas = [
+            ["tomato", "mozzarella"],
+            ["olives", "tomato"]
+        ]
+        expected_unique_ingredients = set(["tomato", "mozzarella", "olives"])
+
+        ingredients = get_unique_ingredients(pizzas)
+
+        self.assertEqual(ingredients, expected_unique_ingredients)
+
+    def test_unique_ingredients_sample(self):
+        ingredients = get_unique_ingredients(self.SAMPLE_PIZZAS)
+
+        self.assertEqual(
+            ingredients,
+            self.SAMPLE_UNIQUE_INGREDIENTS)


### PR DESCRIPTION
* get_unique_ingredients() to take in input a list of pizzas (each being a list
  of ingredients), not a list of pizza indexes of PIZZAS
* get_unique_ingredients() to work directly on set()
* update units tests
* move PIZZAS to unit tests as SAMPLE_PIZZAS, and define corresponding
  SAMPLE_UNIQUE_INGREDIENTS

```
(venv) ✔ ~/PycharmProjects/pizzeria [feature/refactor-get_unique_ingredients|…6] 
17:42 $ python -m unittest
..
----------------------------------------------------------------------
Ran 2 tests in 0.001s

OK
(venv) ✔ ~/PycharmProjects/pizzeria [feature/refactor-get_unique_ingredients|…6] 
17:42 $ coverage run -m unittest
..
----------------------------------------------------------------------
Ran 2 tests in 0.001s

OK
(venv) ✔ ~/PycharmProjects/pizzeria [feature/refactor-get_unique_ingredients|…6] 
17:42 $ coverage report -m
Name                    Stmts   Miss  Cover   Missing
-----------------------------------------------------
pizzeria/__init__.py        0      0   100%
pizzeria/helpers.py         5      0   100%
tests/__init__.py           0      0   100%
tests/test_helpers.py      13      0   100%
-----------------------------------------------------
TOTAL                      18      0   100%
```